### PR TITLE
Change Ellipsis defaults to package-wide _SENTINEL object

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,6 @@ Components can be created large and then later broken down into a batch of multi
 ## TO DO:
 - change SpaceCallback call signature
 - 'take_first' merge function `lambda *sets: sets[0]`
-- fix ellipsis kwarg typing
-- use mypy typecheck
 
 - dynamic handlers?
 - 3.11 typing features

--- a/src/pyriak/__init__.py
+++ b/src/pyriak/__init__.py
@@ -22,15 +22,15 @@ from collections.abc import (
   Generator as _Generator,
   MutableSequence as _MutableSequence,
 )
+from enum import Enum as _Enum
 from typing import (
   Any as _Any,
+  Literal as _Literal,
   TypeAlias as _TypeAlias,
   TypeVar as _TypeVar,
   overload as _overload,
 )
 from weakref import ref as _weakref
-
-from pyriak.eventkey import NoKey, NoKeyType, key_functions, set_key
 
 
 _TypeT = _TypeVar('_TypeT', bound=type)
@@ -153,9 +153,16 @@ class Callback:
     return self.callback(*args, *self.args, **kwargs, **self.kwargs)
 
 
+class _Sentinel(_Enum):
+  SENTINEL = 1
+
+_SENTINEL = _Sentinel.SENTINEL
+
+
 # circular imports
 from pyriak import _importer  # noqa: E402
 from pyriak.entity import Entity, EntityId  # noqa: E402
+from pyriak.eventkey import NoKey, NoKeyType, key_functions, set_key  # noqa: E402
 from pyriak.query import Query  # noqa: E402
 from pyriak.space import Space  # noqa: E402
 from pyriak.system import System, bind  # noqa: E402
@@ -165,4 +172,4 @@ _importer.install()  # install meta path finder for system initialization
 
 
 # cleanup namespace
-del _MutableSequence, _TypeVar, _weakref
+del _MutableSequence, _Enum, _Literal, _TypeVar, _weakref

--- a/src/pyriak/entity.py
+++ b/src/pyriak/entity.py
@@ -1,10 +1,10 @@
 __all__ = ['Entity']
 
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, NewType, TypeVar
+from typing import TYPE_CHECKING, Any, NewType, TypeVar, overload
 from uuid import uuid4
 
-from pyriak import dead_weakref, subclasses
+from pyriak import _SENTINEL, dead_weakref, subclasses
 from pyriak.events import ComponentAdded, ComponentRemoved
 
 
@@ -103,7 +103,11 @@ class Entity:
         return components[cls]
     return default
 
-  def pop(self, component_type: type[_T], default: _D = ..., /) -> _T | _D:
+  @overload
+  def pop(self, component_type: type[_T], /) -> _T: ...
+  @overload
+  def pop(self, component_type: type[_T], default: _D, /) -> _T | _D: ...
+  def pop(self, component_type, default=_SENTINEL, /):
     try:
       component = self[component_type]
     except KeyError:

--- a/src/pyriak/entity.py
+++ b/src/pyriak/entity.py
@@ -111,7 +111,7 @@ class Entity:
     try:
       component = self[component_type]
     except KeyError:
-      if default is Ellipsis:
+      if default is _SENTINEL:
         raise
       return default
     self.remove(component)

--- a/src/pyriak/managers/entitymanager.py
+++ b/src/pyriak/managers/entitymanager.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable, Iterator, KeysView
 from typing import Any, Callable, NoReturn, TypeVar, overload
 from weakref import ref as weakref
 
-from pyriak import EventQueue, dead_weakref, subclasses
+from pyriak import _SENTINEL, EventQueue, dead_weakref, subclasses
 from pyriak.entity import Entity, EntityId
 from pyriak.events import ComponentAdded, ComponentRemoved, EntityAdded, EntityRemoved
 from pyriak.query import ComponentQueryResult, EntityQueryResult, IdQueryResult, Query
@@ -142,11 +142,15 @@ class EntityManager:
   def get(self, entity_id: EntityId, default: _T = None, /) -> Entity | _T:
     return self._entities.get(entity_id, default)
 
-  def pop(self, entity_id: EntityId, default: _T = ..., /) -> Entity | _T:
+  @overload
+  def pop(self, entity_id: EntityId, /) -> Entity: ...
+  @overload
+  def pop(self, entity_id: EntityId, default: _T, /) -> Entity | _T: ...
+  def pop(self, entity_id, default=_SENTINEL, /):
     try:
       entity = self._entities[entity_id]
     except KeyError:
-      if default is Ellipsis:
+      if default is _SENTINEL:
         raise
       return default
     self.remove(entity)

--- a/src/pyriak/managers/statemanager.py
+++ b/src/pyriak/managers/statemanager.py
@@ -97,7 +97,7 @@ class StateManager:
     try:
       state = self[state_type]
     except KeyError:
-      if default is Ellipsis:
+      if default is _SENTINEL:
         raise
       return default
     self.remove(state)

--- a/src/pyriak/managers/statemanager.py
+++ b/src/pyriak/managers/statemanager.py
@@ -1,9 +1,9 @@
 __all__ = ['StateManager']
 
 from collections.abc import Iterable
-from typing import Any, TypeVar
+from typing import Any, TypeVar, overload
 
-from pyriak import EventQueue, subclasses
+from pyriak import _SENTINEL, EventQueue, subclasses
 from pyriak.events import StateAdded, StateRemoved
 
 
@@ -89,7 +89,11 @@ class StateManager:
         return states[cls]
     return default
 
-  def pop(self, state_type: type[_T], default: _D = ..., /) -> _T | _D:
+  @overload
+  def pop(self, state_type: type[_T], /) -> _T: ...
+  @overload
+  def pop(self, state_type: type[_T], default: _D, /) -> _T | _D: ...
+  def pop(self, state_type, default=_SENTINEL, /):
     try:
       state = self[state_type]
     except KeyError:

--- a/src/pyriak/space.py
+++ b/src/pyriak/space.py
@@ -13,26 +13,26 @@ class Space:
 
   def __init__(
     self, *,
-    systems: managers.SystemManager = ...,
-    entities: managers.EntityManager = ...,
-    states: managers.StateManager = ...,
-    event_queue: EventQueue = ...
+    systems: managers.SystemManager | None = None,
+    entities: managers.EntityManager | None = None,
+    states: managers.StateManager | None = None,
+    event_queue: EventQueue | None = None
   ):
     """A new Space instance, which glues together the managers and the event queue.
 
     By default, creates the EntityManager, StateManager, and SystemManager.
     """
-    if systems is Ellipsis:
+    if systems is None:
       systems = managers.SystemManager()
       systems.space = self
     self.systems = systems
-    if entities is Ellipsis:
+    if entities is None:
       entities = managers.EntityManager()
     self.entities = entities
-    if states is Ellipsis:
+    if states is None:
       states = managers.StateManager()
     self.states = states
-    if event_queue is Ellipsis:
+    if event_queue is None:
       event_queue = deque()
     self.event_queue = event_queue
 
@@ -42,15 +42,7 @@ class Space:
 
   @event_queue.setter
   def event_queue(self, value: EventQueue):
-    self._event_queue = value
-    if self.entities is not None:
-      self.entities.event_queue = value
-    if self.states is not None:
-      self.states.event_queue = value
-
-  @event_queue.deleter
-  def event_queue(self):
-    del self._event_queue
+    self._event_queue = self.entities.event_queue = self.states.event_queue = value
 
   @overload
   def query(self, query: Query, /) -> ComponentQueryResult: ...

--- a/src/pyriak/space.py
+++ b/src/pyriak/space.py
@@ -43,9 +43,10 @@ class Space:
   @event_queue.setter
   def event_queue(self, value: EventQueue):
     self._event_queue = value
-    for manager in (self.entities,self.states):
-      if manager is not None:
-        manager.event_queue = value
+    if self.entities is not None:
+      self.entities.event_queue = value
+    if self.states is not None:
+      self.states.event_queue = value
 
   @event_queue.deleter
   def event_queue(self):


### PR DESCRIPTION
Ellipsis default typing as a sentinel worked in pyright, but not in mypy.
A new sentinel object (package private) is implemented as an enum value.