### PR TITLE
Remove built-in subtyping polymorphism

### DIFF
--- a/src/pyriak/__init__.py
+++ b/src/pyriak/__init__.py
@@ -23,7 +23,7 @@
 
 """Pyriak is a framework for ECS architecture.
 
-This implementation integrates the concepts of event handling and polymorphism.
+This implementation also implements event-driven architecture.
 The package is written in pure python and has no dependencies.
 
 This module is the top-level module of the package and contains

--- a/src/pyriak/__init__.py
+++ b/src/pyriak/__init__.py
@@ -37,8 +37,6 @@ __all__ = [
   'EntityId',
   'System',
   'EventQueue',
-  'subclasses',
-  'strict_subclasses',
   'key_functions',
   'set_key',
   'tagclass',
@@ -46,7 +44,6 @@ __all__ = [
 ]
 
 from collections.abc import (
-  Generator as _Generator,
   Hashable as _Hashable,
   MutableSequence as _MutableSequence,
 )
@@ -71,47 +68,6 @@ EventQueue: _TypeAlias = _MutableSequence[object]
 
 
 dead_weakref: _weakref[_Any] = _weakref(set())
-
-
-_get_subclasses = type.__subclasses__
-
-def subclasses(cls: _TypeT, /) -> _Generator[_TypeT, None, _TypeT]:
-  """Generator of the class and all of the class's subclasses.
-
-  Metaclasses also work.
-  There may be duplicates in the case of multiple inheritance.
-  Note: overridden implementations of __subclasses__ are ignored
-  because type.__subclasses__ is used, which also prevents cycles.
-
-  The order the classes are returned is not specified, however:
-  It is guaranteed that the cls passed in is the first class yielded.
-  For a tree inheritance structure (single inheritance only), a subclass
-  will never be yielded before any of its superclasses.
-
-  'Return' the cls passed in. (This value is accessible through
-  the StopIteration that is raised).
-  """
-  yield cls
-  get_subclasses = _get_subclasses
-  stack = get_subclasses(cls)
-  pop = stack.pop
-  while stack:
-    subclass = pop()
-    yield subclass
-    stack += get_subclasses(subclass)
-  return cls
-
-
-def strict_subclasses(cls: _TypeT, /) -> _Generator[_TypeT, None, _TypeT]:
-  """Same as subclasses, but does not yield the original class."""
-  get_subclasses = _get_subclasses
-  stack = get_subclasses(cls)
-  pop = stack.pop
-  while stack:
-    subclass = pop()
-    yield subclass
-    stack += get_subclasses(subclass)
-  return cls
 
 
 def tagclass(cls: type) -> type:

--- a/src/pyriak/bind.py
+++ b/src/pyriak/bind.py
@@ -96,7 +96,7 @@ def bind(event_type, priority, /, *, key=_SENTINEL, keys=_SENTINEL):
     keys = frozenset([key])
   else:
     keys = frozenset(keys) if keys is not _SENTINEL else _empty_frozenset
-  if keys and not key_functions.exists(event_type):
+  if keys and event_type not in key_functions:
     raise ValueError(
       f'bind(): keys were provided but no key function exists for {event_type!r}'
     )

--- a/src/pyriak/entity.py
+++ b/src/pyriak/entity.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, NewType, TypeVar, overload
 from uuid import uuid4
 
-from pyriak import _SENTINEL, dead_weakref, strict_subclasses, subclasses
+from pyriak import _SENTINEL, dead_weakref
 
 
 if TYPE_CHECKING:
@@ -67,25 +67,8 @@ class Entity:
           continue
       raise ValueError(component)
 
-  def __call__(self, *component_types: type[_T]) -> list[_T]:
-    components = self._components
-    return [
-      components[component_type]  # type: ignore
-      for component_type in {
-        comp_type: None for cls in component_types for comp_type in subclasses(cls)
-      }  # dict instead of set to guarantee stable ordering while still removing dupes
-      if component_type in components
-    ]
-
   def __getitem__(self, component_type: type[_T], /) -> _T:
-    try:
-      return self._components[component_type]  # type: ignore[return-value]
-    except KeyError:
-      components = self._components
-      for cls in strict_subclasses(component_type):
-        if cls in components:
-          return components[cls]  # type: ignore[return-value]
-      raise
+    return self._components[component_type]  # type: ignore[return-value]
 
   def __setitem__(self, component_type: type[_T], component: _T, /):
     self.pop(component_type, None)
@@ -99,15 +82,7 @@ class Entity:
   @overload
   def get(self, component_type: type[_T], default: _D, /) -> _T | _D: ...
   def get(self, component_type, default=None, /):
-    try:
-      return self._components[component_type]
-    except KeyError:
-      pass
-    components = self._components
-    for cls in strict_subclasses(component_type):
-      if cls in components:
-        return components[cls]
-    return default
+    return self._components.get(component_type, default)
 
   @overload
   def pop(self, component_type: type[_T], /) -> _T: ...
@@ -115,7 +90,7 @@ class Entity:
   def pop(self, component_type: type[_T], default: _D, /) -> _T | _D: ...
   def pop(self, component_type, default=_SENTINEL, /):
     try:
-      component = self[component_type]
+      component = self._components[component_type]
     except KeyError:
       if default is _SENTINEL:
         raise
@@ -136,14 +111,7 @@ class Entity:
     return len(self._components)
 
   def __contains__(self, obj: object, /):
-    if obj in self._components:
-      return True
-    if isinstance(obj, type):
-      components = self._components
-      for cls in strict_subclasses(obj):
-        if cls in components:
-          return True
-    return False
+    return obj in self._components
 
   def __eq__(self, other: object, /):
     if self is other:

--- a/src/pyriak/events.py
+++ b/src/pyriak/events.py
@@ -11,10 +11,9 @@ __all__ = [
   'StateRemoved',
 ]
 
-from collections.abc import Hashable, Iterator
+from collections.abc import Hashable
 from typing import TYPE_CHECKING, Any
 
-from pyriak import subclasses as _subclasses
 from pyriak.eventkey import set_key as _set_key
 
 
@@ -34,8 +33,8 @@ class EntityRemoved:
     self.entity = entity
 
 
-def _component_type_key(event: 'ComponentAdded | ComponentRemoved') -> Iterator[type]:
-  yield from type(event.component).__mro__
+def _component_type_key(event: 'ComponentAdded | ComponentRemoved') -> type:
+  return type(event.component)
 
 @_set_key(_component_type_key)
 class ComponentAdded:
@@ -64,8 +63,8 @@ class SystemRemoved:
     self.system = system
 
 
-def _state_type_key(event: 'StateAdded | StateRemoved') -> Iterator[type]:
-  yield from type(event.state).__mro__
+def _state_type_key(event: 'StateAdded | StateRemoved') -> type:
+  return type(event.state)
 
 @_set_key(_state_type_key)
 class StateAdded:
@@ -78,8 +77,8 @@ class StateRemoved:
     self.state = state
 
 
-def _handler_key(event: 'EventHandlerAdded | EventHandlerRemoved') -> Iterator[type]:
-  yield from _subclasses(event.event_type)
+def _handler_key(event: 'EventHandlerAdded | EventHandlerRemoved') -> type:
+  return event.event_type
 
 @_set_key(_handler_key)
 class EventHandlerAdded:

--- a/src/pyriak/managers/entitymanager.py
+++ b/src/pyriak/managers/entitymanager.py
@@ -40,19 +40,8 @@ class QueryResult:
   def merge(self) -> Callable[..., set]:
     return self._merge
 
-  @overload
-  def __call__(self) -> Iterator[Any]: ...
-  @overload
-  def __call__(self, *component_types: type[_T]) -> Iterator[_T]: ...
-  def __call__(self, *component_types):
-    if not component_types:
-      component_types = self.types
-    return (comp for ent in self.entities for comp in ent(*component_types))
-
-  def __getitem__(self, component_type: type[_T], /) -> Iterator[_T]:
-    return (ent[component_type] for ent in self.entities)
-
-  #= get method?
+  def __call__(self, component_type: type[_T], /) -> Iterator[_T]:
+    return (entity[component_type] for entity in self.entities)
 
   @overload
   def zip(self) -> Iterator[tuple[Any, ...]]: ...
@@ -96,16 +85,9 @@ class _Components:
     manager = self._manager()
     entities = manager._entities
     return (
-      component
+      entities[entity_id][component_type]
       for entity_id in manager._component_types.get(component_type, ())
-      for component in entities[entity_id](component_type)
     )
-
-  def __getitem__(self, component_type: type[_T], /) -> Iterator[_T]:
-    manager = self._manager()
-    entities = manager._entities
-    return (entities[entity_id][component_type]
-            for entity_id in manager._component_types.get(component_type, ()))
 
   def types(self) -> KeysView[type]:
     return self._manager()._component_types.keys()

--- a/src/pyriak/managers/entitymanager.py
+++ b/src/pyriak/managers/entitymanager.py
@@ -4,7 +4,7 @@ from collections.abc import Collection, Iterable, Iterator, KeysView, Set as Abs
 from typing import Any, Callable, TypeVar, overload
 from weakref import ref as weakref
 
-from pyriak import _SENTINEL, EventQueue, dead_weakref, subclasses
+from pyriak import _SENTINEL, EventQueue, dead_weakref
 from pyriak.entity import Entity, EntityId
 from pyriak.events import ComponentAdded, ComponentRemoved, EntityAdded, EntityRemoved
 
@@ -104,12 +104,7 @@ class _Components:
     return sum(len(entity) for entity in self._manager()._entities.values())
 
   def __contains__(self, obj: object, /):
-    types = self._manager()._component_types
-    if isinstance(obj, type):
-      for cls in subclasses(obj):
-        if cls in types:
-          return True
-    return False
+    return obj in self._manager()._component_types
 
 
 class EntityManager:
@@ -138,9 +133,7 @@ class EntityManager:
         raise RuntimeError(f'{entity!r} already added to another manager')
       self_entities[entity_id] = entity
       entity._manager = self_weakref
-      for component_type in {
-        component_type for cls in entity.types() for component_type in cls.__mro__
-      }:
+      for component_type in entity.types():
         try:
           component_types[component_type].add(entity_id)
         except KeyError:
@@ -170,9 +163,7 @@ class EntityManager:
       except KeyError:
         raise ValueError(entity) from None
       entity._manager = dead_weakref
-      for component_type in {
-        component_type for cls in entity.types() for component_type in cls.__mro__
-      }:
+      for component_type in entity.types():
         component_type_entities = component_types[component_type]
         component_type_entities.remove(entity_id)
         if not component_type_entities:
@@ -277,27 +268,19 @@ class EntityManager:
     self.remove(*self)
 
   def _component_added(self, entity: Entity, component: object, /) -> None:
-    component_types = self._component_types
-    entity_id = entity.id
-    for component_type in type(component).__mro__:
-      try:
-        component_types[component_type].add(entity_id)
-      except KeyError:
-        component_types[component_type] = {entity_id}
+    try:
+      self._component_types[type(component)].add(entity.id)
+    except KeyError:
+      self._component_types[type(component)] = {entity.id}
     event_queue = self.event_queue
     if event_queue is not None:
       event_queue.append(ComponentAdded(entity, component))
 
   def _component_removed(self, entity: Entity, component: object, /) -> None:
-    component_types = self._component_types
-    entity_id = entity.id
-    for component_type in type(component).__mro__:
-      if component_type in entity:
-        continue
-      entity_ids = component_types[component_type]
-      entity_ids.remove(entity_id)
-      if not entity_ids:
-        del component_types[component_type]
+    entity_ids = self._component_types[type(component)]
+    entity_ids.remove(entity.id)
+    if not entity_ids:
+      del self._component_types[type(component)]
     event_queue = self.event_queue
     if event_queue is not None:
       event_queue.append(ComponentRemoved(entity, component))

--- a/src/pyriak/managers/statemanager.py
+++ b/src/pyriak/managers/statemanager.py
@@ -3,7 +3,7 @@ __all__ = ['StateManager']
 from collections.abc import Iterable
 from typing import TypeVar, overload
 
-from pyriak import _SENTINEL, EventQueue, strict_subclasses, subclasses
+from pyriak import _SENTINEL, EventQueue
 from pyriak.events import StateAdded, StateRemoved
 
 
@@ -58,25 +58,8 @@ class StateManager:
           continue
       raise ValueError(state)
 
-  def __call__(self, *state_types: type[_T]) -> list[_T]:
-    states = self._states
-    return [
-      states[state_type]  # type: ignore
-      for state_type in {
-        state_type: None for cls in state_types for state_type in subclasses(cls)
-      }  # dict instead of set to guarantee stable ordering while still removing dupes
-      if state_type in states
-    ]
-
   def __getitem__(self, state_type: type[_T], /) -> _T:
-    try:
-      return self._states[state_type]  # type: ignore[return-value]
-    except KeyError:
-      states = self._states
-      for cls in strict_subclasses(state_type):
-        if cls in states:
-          return states[cls]  # type: ignore[return-value]
-      raise
+    return self._states[state_type]  # type: ignore[return-value]
 
   def __setitem__(self, state_type: type[_T], state: _T, /):
     self.pop(state_type, None)
@@ -90,15 +73,7 @@ class StateManager:
   @overload
   def get(self, state_type: type[_T], default: _D, /) -> _T | _D: ...
   def get(self, state_type, default=None, /):
-    try:
-      return self._states[state_type]
-    except KeyError:
-      pass
-    states = self._states
-    for cls in strict_subclasses(state_type):
-      if cls in states:
-        return states[cls]
-    return default
+    return self._states.get(state_type, default)
 
   @overload
   def pop(self, state_type: type[_T], /) -> _T: ...
@@ -127,14 +102,7 @@ class StateManager:
     return len(self._states)
 
   def __contains__(self, obj: object, /):
-    if obj in self._states:
-      return True
-    if isinstance(obj, type):
-      states = self._states
-      for cls in strict_subclasses(obj):
-        if cls in states:
-          return True
-    return False
+    return obj in self._states
 
   def clear(self) -> None:
     self.remove(*self)

--- a/src/pyriak/managers/systemmanager.py
+++ b/src/pyriak/managers/systemmanager.py
@@ -273,14 +273,14 @@ class SystemManager:
       handlers = self._handlers[event_type]
     except KeyError:
       handlers = self._lazy_bind(event_type)
-      if not key_functions.exists(event_type):
+      if event_type not in key_functions:
         return handlers
       key_handlers = self._lazy_key_bind(event_type)
     else:
       if event_type not in self._key_handlers:
         return handlers
       key_handlers = self._key_handlers[event_type]
-    key = key_functions(event_type)(event)
+    key = key_functions[event_type](event)
     if not isinstance(key, Iterator):
       try:
         return key_handlers[key]
@@ -339,7 +339,7 @@ class SystemManager:
         }
         key_event_types = event_handlers.keys() & all_key_handlers
         event_handlers[event_type] = handler
-        if key_functions.exists(event_type):
+        if event_type in key_functions:
           key_event_types.add(event_type)
         handler_keys: dict[type, Mapping[Hashable, _EventHandler]] = (
           fromkeys(key_event_types, fromkeys(binding_keys, handler))
@@ -388,7 +388,7 @@ class SystemManager:
             raise RuntimeError
         handler_keys = {}
         key_event_types = event_handlers.keys() & all_key_handlers
-        key_event_types |= {ev_t for ev_t in event_types if key_functions.exists(ev_t)}
+        key_event_types |= {ev_t for ev_t in event_types if ev_t in key_functions}
         for cls in key_event_types:
           inherit_handler_keys: dict[Hashable, _EventHandler] = {}
           total_len = 0

--- a/src/pyriak/managers/systemmanager.py
+++ b/src/pyriak/managers/systemmanager.py
@@ -331,21 +331,20 @@ class SystemManager:
         if event_type not in key_functions:
           continue
         if event_type not in all_key_handlers:
-          if not keys:
-            all_key_handlers[event_type] = {}
-            continue
           handlers = all_handlers[event_type]
           all_key_handlers[event_type] = {key: handlers[:] for key in keys}
-        elif keys:
-          key_handlers = all_key_handlers[event_type]
-          handlers = all_handlers[event_type]
-          for key in keys:
-            if key not in key_handlers:
-              key_handlers[key] = handlers[:]
-            insert_handler(key_handlers[key], handler)
           continue
-        for handlers in all_key_handlers[event_type].values():
-          insert_handler(handlers, handler)
+        key_handlers = all_key_handlers[event_type]
+        if not keys:
+          for handlers in key_handlers.values():
+            insert_handler(handlers, handler)
+          continue
+        handlers = all_handlers[event_type]
+        for key in keys:
+          if key in key_handlers:
+            insert_handler(key_handlers[key], handler)
+          else:
+            key_handlers[key] = handlers[:]
     return events
 
   def _unbind(self, system: System, /) -> list[EventHandlerRemoved]:

--- a/src/pyriak/managers/systemmanager.py
+++ b/src/pyriak/managers/systemmanager.py
@@ -94,7 +94,7 @@ class SystemManager:
     space = self.space
     if space is None:
       raise TypeError("process() missing 'space'")
-    for handler in self._get_handlers(event)[:]:  # noqa: SIM110
+    for handler in self._get_handlers(event):  # noqa: SIM110
       if handler.callback(space, event):
         return True
     return False
@@ -274,22 +274,22 @@ class SystemManager:
     except KeyError:
       return []
     if event_type not in key_functions:
-      return handlers
+      return handlers[:]
     try:
       key_handlers = self._key_handlers[event_type]
     except KeyError:
       # A key function was added late
       self._key_handlers[event_type] = {}
-      return handlers
+      return handlers[:]
     key = key_functions[event_type](event)
     if not isinstance(key, Iterator):
-      return key_handlers.get(key, handlers)
+      return (key_handlers.get(key, handlers))[:]
     keys = {k for k in key if k in key_handlers}
     if len(keys) > 1:
       return self._sort_handlers(
         [handler for key in keys for handler in key_handlers[key]]
       )
-    return key_handlers.get(keys.pop(), handlers) if keys else handlers
+    return (key_handlers.get(keys.pop(), handlers) if keys else handlers)[:]
 
   @staticmethod
   def _get_bindings(system: System):


### PR DESCRIPTION
The original design of this architecture included functionality for subtyping polymorphism (Liskov substitution principle) for components, states, and events.
However, it has become clear that this is a rarely used feature with many hidden drawbacks.

The benefits of removing it:
- No longer encourages OOP-like design (a composition based approach is usually better)
- Less cluttered, more intuitive interfaces for the built-in classes
- Massively reduced complexity of package source code
- Slight performance increase
- Package no longer relies on obscure `__subclasses__()` built-in method
- Don't have to worry about getting a possible subclass, or handling multiple components of a type, for an entity
- Same as basically all other implementations of ECS

Some negatives:
- Slightly more difficult implementation for extending or abstracting existing components
- Cannot bind `object` to listen for all events processed
- Can no longer use a bunch of subclasses to put multiple of same/similar components on a single entity