### PR TITLE
Remove multibinding

### DIFF
--- a/src/pyriak/events.py
+++ b/src/pyriak/events.py
@@ -206,8 +206,8 @@ class _EventHandlerEvent:
 class EventHandlerAdded(_EventHandlerEvent):
   """An event for when a single event handler is added.
 
-  When a system is added to the SystemManager, it may have bindings,
-  and each binding has event handlers (one per event type) to add.
+  When a system is added to the SystemManager, it may have bindings.
+  For each binding, an event handler is created on the manager.
 
   The event key is the event type of the handler.
 
@@ -225,8 +225,8 @@ class EventHandlerAdded(_EventHandlerEvent):
 class EventHandlerRemoved(_EventHandlerEvent):
   """An event for when a single event handler is removed.
 
-  A system removed from the SystemManager may have event
-  handlers to be removed.
+  A system removed from the SystemManager may own event
+  handlers that need to be removed.
 
   The event key is the event type of the handler.
 

--- a/src/pyriak/events.py
+++ b/src/pyriak/events.py
@@ -29,7 +29,7 @@ from pyriak.eventkey import set_key as _set_key
 
 if TYPE_CHECKING:
   from pyriak import System
-  from pyriak.bind import BindingWrapper, _Callback
+  from pyriak.bind import Binding, _Callback
   from pyriak.entity import Entity
   from pyriak.system_manager import _EventHandler
 
@@ -162,7 +162,7 @@ def _handler_key(event: 'EventHandlerAdded | EventHandlerRemoved') -> type:
 
 class _EventHandlerEvent:
   def __init__(
-    self, _binding: 'BindingWrapper', _handler: '_EventHandler'
+    self, _binding: 'Binding', _handler: '_EventHandler'
   ):
     self._binding = _binding
     self._handler = _handler

--- a/src/pyriak/system_manager.py
+++ b/src/pyriak/system_manager.py
@@ -393,10 +393,10 @@ class SystemManager:
     ]
 
   def _bind(self, system: System, /) -> list[EventHandlerAdded]:
-    """Bind a system's handlers so that they can process events.
+    """Create handlers to process events for a system's bindings.
 
-    Bindings of an event type are sorted by highest priority,
-    then oldest system, then first one bound in system.
+    Handlers of one event type are sorted by highest priority,
+    then oldest system, then first one created in manager.
     """
     all_handlers = self._handlers
     all_key_handlers = self._key_handlers

--- a/src/pyriak/system_manager.py
+++ b/src/pyriak/system_manager.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 from weakref import ref as weakref
 
 from pyriak import EventQueue, System, dead_weakref
-from pyriak.bind import BindingWrapper, _Callback
+from pyriak.bind import Binding, _Callback
 from pyriak.eventkey import key_functions
 from pyriak.events import (
   EventHandlerAdded,
@@ -372,12 +372,11 @@ class SystemManager:
     return (key_handlers.get(keys.pop(), handlers) if keys else handlers)[:]
 
   @staticmethod
-  def _get_bindings(system: System) -> list[tuple[BindingWrapper, _EventHandler]]:
+  def _get_bindings(system: System) -> list[tuple[Binding, _EventHandler]]:
     if type(system) is ModuleType:
       return [
         (binding, _EventHandler(system, binding._callback_, name, binding._priority_))
-        for name, binding in system.__dict__.items()
-        if isinstance(binding, BindingWrapper)
+        for name, binding in system.__dict__.items() if isinstance(binding, Binding)
       ]
     return [
       (
@@ -390,7 +389,7 @@ class SystemManager:
         )
       )
       for name in dict.fromkeys(dir(system))  # remove duplicates
-      if isinstance(binding:=getattr_static(system, name), BindingWrapper)
+      if isinstance(binding:=getattr_static(system, name), Binding)
     ]
 
   def _bind(self, system: System, /) -> list[EventHandlerAdded]:


### PR DESCRIPTION
`bind()` has been able to be applied to a callback multiple times. However, there are benefits to removing this rarely used feature.
- Simplified event handler binding and unbinding code
- Slightly less memory usage
- Less classes needed
- Clearer terms and names of internal classes and concepts
- Improved event handler events
- Less complex overall as only one handler per binding
- Simpler type annotations, avoids multibinding typing issue

Drawback:
- Harder to bind multiple events to a general handler (rare)