### PR TITLE
Event handler changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ Additionally, there are helper container classes to manage these objects.\
 #### pyriak implementations
 The following are how the above terms are implemented in pyriak.
 - entity: `Entity` class, containing a unique entity ID and a set of components referenced by class
-- system: usually a module object with event handlers and functions defined on it, static and holds no data
+- system: a module object with event handlers and functions defined on it, static and holds no data
 - component, event, state: user-defined classes containing mostly data and little behavior
   - akin to a struct in other languages. The `dataclasses` module and other similar utilities are useful for defining these
 - managers:
   - `EntityManager`: a set of entities referenced by their ID, with querying operations available
-  - `SystemManager`: a set of hashable system objects, can process events by invoking the relevant event handlers
+  - `SystemManager`: a set of system objects, can process events by invoking the relevant event handlers
   - `StateManager`: a set of states referenced by their class, akin to an entity
 - space: `Space` class, with attributes `.entities`, `.systems`, and `.states` for the managers, and `.event_queue`
 - event queue: a `collections.deque` by default, attached to the space

--- a/src/pyriak/__init__.py
+++ b/src/pyriak/__init__.py
@@ -43,8 +43,9 @@ __all__ = [
     "tag_types",
 ]
 
-from collections.abc import Hashable as _Hashable, MutableSequence as _MutableSequence
+from collections.abc import MutableSequence as _MutableSequence
 from enum import Enum as _Enum
+from types import ModuleType as _ModuleType
 from typing import (
     Any as _Any,
     Final as _Final,
@@ -53,7 +54,7 @@ from typing import (
 )
 from weakref import ref as _weakref
 
-System: _TypeAlias = _Hashable
+System: _TypeAlias = _ModuleType
 
 
 EventQueue: _TypeAlias = _MutableSequence[object]
@@ -81,4 +82,4 @@ NULL_ID: _Final[EntityId] = EntityId(0)
 
 
 # cleanup namespace
-del _Hashable, _MutableSequence, _Enum, _weakref
+del _MutableSequence, _Enum, _ModuleType, _weakref

--- a/src/pyriak/bind.py
+++ b/src/pyriak/bind.py
@@ -108,12 +108,15 @@ def bind(
     This does not include subclasses of the event type. The types must be exact.
 
     The priority determines the order in which callbacks are invoked if there
-    are multiple systems or event handlers for that event.
+    are multiple event handlers for that event.
+    This priority only applies within handlers with the same event key or no key.
 
     The optional key or keys further narrow which events are handled.
+    This is only valid for event types with key functions.
     The event must give at least one key that matches the binding,
     if the binding has any keys.
-    This is only valid for event types with key functions.
+    The handler may be invoked multiple times if multiple of the handler's keys
+    are matched, or if the event keys contain duplicates.
 
     bind() cannot be used multiple times on the same object.
 

--- a/src/pyriak/events.py
+++ b/src/pyriak/events.py
@@ -184,20 +184,20 @@ class _EventHandlerEvent(Generic[_T]):
     _handler: "_EventHandler[_T]"
 
     @property
-    def system(self) -> System:
-        return self._handler.system
-
-    @property
     def callback(self) -> "_Callback[_T, Any]":
         return self._handler.callback
 
     @property
-    def name(self) -> str:
-        return self._handler.name
-
-    @property
     def priority(self) -> Any:
         return self._binding._priority_
+
+    @property
+    def system(self) -> System:
+        return self._handler.system
+
+    @property
+    def name(self) -> str:
+        return self._handler.name
 
     @property
     def event_type(self) -> type[_T]:

--- a/src/pyriak/events.py
+++ b/src/pyriak/events.py
@@ -25,11 +25,11 @@ from collections.abc import Hashable, Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
+from pyriak import System
 from pyriak.event_key import set_key as _set_key
 from pyriak.tag_component import tag_types as _tag_types
 
 if TYPE_CHECKING:
-    from pyriak import System
     from pyriak.bind import Binding, _Callback
     from pyriak.entity import Entity
     from pyriak.system_manager import _EventHandler
@@ -110,7 +110,7 @@ class ComponentRemoved(Generic[_T]):
     component: _T
 
 
-def _system_key(event: "SystemAdded | SystemRemoved") -> "System":
+def _system_key(event: "SystemAdded | SystemRemoved") -> System:
     return event.system
 
 
@@ -125,7 +125,7 @@ class SystemAdded:
         system: The system added to the manager.
     """
 
-    system: "System"
+    system: System
 
 
 @_set_key(_system_key)
@@ -139,7 +139,7 @@ class SystemRemoved:
         system: The system removed from the manager.
     """
 
-    system: "System"
+    system: System
 
 
 def _state_type_key(event: "StateAdded | StateRemoved") -> type:
@@ -184,7 +184,7 @@ class _EventHandlerEvent(Generic[_T]):
     _handler: "_EventHandler[_T]"
 
     @property
-    def system(self) -> "System":
+    def system(self) -> System:
         return self._handler.system
 
     @property
@@ -230,7 +230,7 @@ class EventHandlerAdded(_EventHandlerEvent[_T]):
     Attributes:
         system: The system of the event handler.
         callback: The callback of the event handler.
-        name: The attribute name of the binding on the system.
+        name: The function variable name of the binding on the system.
         priority: The priority of the event handler.
         event_type: The event type of the event handler.
         keys: The keys of the event handler. May be empty.
@@ -249,7 +249,7 @@ class EventHandlerRemoved(_EventHandlerEvent[_T]):
     Attributes:
         system: The system of the event handler.
         callback: The callback of the event handler.
-        name: The attribute name of the binding on the system.
+        name: The function variable name of the binding on the system.
         priority: The priority of the event handler.
         event_type: The event type of the event handler.
         keys: The keys of the event handler. May be empty.

--- a/src/pyriak/events.py
+++ b/src/pyriak/events.py
@@ -180,11 +180,11 @@ def _handler_key(event: "EventHandlerAdded | EventHandlerRemoved") -> type:
 
 @dataclass
 class _EventHandlerEvent(Generic[_T]):
-    _binding: "Binding[_T, Any]"
+    _binding: "Binding[_T]"
     _handler: "_EventHandler[_T]"
 
     @property
-    def callback(self) -> "_Callback[_T, Any]":
+    def callback(self) -> "_Callback[_T]":
         return self._handler.callback
 
     @property

--- a/src/pyriak/space.py
+++ b/src/pyriak/space.py
@@ -73,7 +73,7 @@ class Space:
         self.states = states
         states.event_queue = event_queue
 
-    def process(self, event: object, /) -> bool:
+    def process(self, event: object, /) -> None:
         """Immediately invoke event handlers for an event.
 
         Syntactic sugar for self.systems.process().
@@ -88,13 +88,10 @@ class Space:
         Args:
             event: The event to process.
 
-        Returns:
-            True if event processing was stopped by a callback, False otherwise.
-
         Raises:
             RuntimeError: If the SystemManager's space is None or deleted.
         """
-        return self.systems.process(event)
+        self.systems.process(event)
 
     def post(self, event: object, /) -> None:
         """Append an event to the end of self's event queue.

--- a/src/pyriak/state_manager.py
+++ b/src/pyriak/state_manager.py
@@ -21,7 +21,7 @@ class StateManager:
     The StateManager can be thought of as the program's dedicated Entity
     instance, where global and unique data can be put, e.g. global time.
     A common use is a system storing data in a state that it 'owns',
-    as systems are not allowed to have any mutable data themselves.
+    as systems shouldn't have any mutable data themselves.
 
     The general purpose of the StateManager is to provide storage for data
     that does not make sense to have multiple of, nor put in an entity.

--- a/src/pyriak/system_manager.py
+++ b/src/pyriak/system_manager.py
@@ -143,7 +143,7 @@ class SystemManager:
         self._key_handlers: dict[type, dict[Hashable, list[_EventHandler[Any]]]] = {}
         self.add(*systems)
 
-    def process(self, event: object, /) -> bool:
+    def process(self, event: object, /) -> None:
         """Invoke system event handlers for an event.
 
         Event handlers listen for events of a specific type.
@@ -162,15 +162,10 @@ class SystemManager:
 
         If the event type has no event handlers, nothing happens.
 
-        If a callback returns a truthy value, the rest of the callbacks
-        are skipped and True is returned.
-        If no callback returns a truthy value, False is returned.
+        The return value of the callback is ignored.
 
         Args:
             event: The event to process.
-
-        Returns:
-            True if event processing was stopped by a callback, False otherwise.
 
         Raises:
             RuntimeError: If self's space is None or deleted.
@@ -179,9 +174,7 @@ class SystemManager:
         if space is None:
             raise RuntimeError("cannot process event, space is None or deleted")
         for handler in self._get_handlers(event):
-            if handler.callback(space, event):
-                return True
-        return False
+            handler.callback(space, event)
 
     def add(self, *systems: System) -> None:
         """Add an arbitrary number of systems and their event handlers to self.

--- a/src/pyriak/system_manager.py
+++ b/src/pyriak/system_manager.py
@@ -210,7 +210,7 @@ class SystemManager:
                 event_queue.extend([SystemAdded(system), *events])
             if space is not None:
                 try:
-                    added = system._added_  # type: ignore[attr-defined]
+                    added = system._added_
                 except AttributeError:
                     continue
                 added(space)
@@ -264,7 +264,7 @@ class SystemManager:
                 event_queue.extend([*events, SystemRemoved(system)])
             if space is not None:
                 try:
-                    removed = system._removed_  # type: ignore[attr-defined]
+                    removed = system._removed_
                 except AttributeError:
                     continue
                 removed(space)

--- a/src/pyriak/system_manager.py
+++ b/src/pyriak/system_manager.py
@@ -45,16 +45,16 @@ class _EventHandler(NamedTuple, Generic[_T]):
     Priority comparisons involving equality such as >= are not implemented.
 
     Attributes:
-        system: The system the event handler belongs to.
         callback: The event handler callback to be invoked.
-        name: The function variable name of the binding on the system.
         priority: The priority of the event handler given in bind().
+        system: The system the event handler belongs to.
+        name: The function variable name of the binding on the system.
     """
 
-    system: System
     callback: _Callback[_T, Any]
-    name: str
     priority: Any
+    system: System
+    name: str
 
     def __call__(self, space: "Space", event: _T, /) -> Any:
         return self.callback(space, event)
@@ -373,7 +373,7 @@ class SystemManager:
         return [
             (
                 binding,
-                _EventHandler(system, binding._callback_, name, binding._priority_),
+                _EventHandler(binding._callback_, binding._priority_, system, name),
             )
             for name, binding in system.__dict__.items()
             if isinstance(binding, Binding)

--- a/src/pyriak/system_manager.py
+++ b/src/pyriak/system_manager.py
@@ -51,12 +51,12 @@ class _EventHandler(NamedTuple, Generic[_T]):
         name: The function variable name of the binding on the system.
     """
 
-    callback: _Callback[_T, Any]
+    callback: _Callback[_T]
     priority: Any
     system: System
     name: str
 
-    def __call__(self, space: "Space", event: _T, /) -> Any:
+    def __call__(self, space: "Space", event: _T, /) -> object:
         return self.callback(space, event)
 
     def __eq__(self, other: object) -> bool:


### PR DESCRIPTION
Three event handler-related changes.

1. Systems can now only be `ModuleType`, instead of any `Hashable`. This is to simplify getting handlers and the binding implementation, as arbitrary objects and classes may have complicated attribute access.
2. Key handler priorities are separate for each key. (When there are event keys, the handlers are only ordered by priority within the handlers of the same key or no key.) This is to greatly simplify the handler binding/unbinding and `SystemManager` implementation by removing the need to sort a list of handlers (insorting covers everything). It also makes it faster to add general handlers when there are possibly many registered keys.
    - As a side effect, duplicate handlers are no longer removed and so may be invoked more than once.
    - `_EventHandler` now supports comparison for use in sorting. Now, `bisect.insort_right` is used to insert new handlers. Additionally, the ordering of `_EventHandler` attributes has been changed to make more sense.
3. The return value of event handler callbacks is now ignored. Previously, a truthy return value would cause the rest of the callbacks to get skipped and the `process()` method to return `True` instead of `False`. This feature was not useful because it slightly broke the decoupling of event handlers not knowing or affecting each other. Any time the feature was used, there was a superior design possible such as processing a preceding event. Also, only `space.process()` could give the boolean (that went largely unused), while with `space.post()` this return value could not be recovered.
    - As a side effect, the return value of callbacks is no longer generic and the return type decays into `object` when `@bind()` is used on a callback.